### PR TITLE
feat: add SEO configuration

### DIFF
--- a/docs/chat/messages.md
+++ b/docs/chat/messages.md
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 1
+title: Messages, Formatting, and Mentions
+description: How Mocha relays messages across Discord servers — supported formatting, images, links, stickers, edits, deletes, and the #(Server) and !tmp prefix tricks.
+keywords:
+  - mocha messages
+  - discord message formatting
+  - discord cross server chat
+  - temporary messages
+  - server mentions
 ---
 
 # Messages

--- a/docs/chat/reactions-replies.md
+++ b/docs/chat/reactions-replies.md
@@ -1,5 +1,12 @@
 ---
 sidebar_position: 2
+title: Replies and Pins Across Servers
+description: How Mocha mirrors Discord replies with correct threading and pin actions across every channel in a room, plus the caveats around cache TTL and permissions.
+keywords:
+  - discord reply threading
+  - pinned messages
+  - mocha replies
+  - cross-server replies
 ---
 
 # Replies & Pins

--- a/docs/chat/typing.md
+++ b/docs/chat/typing.md
@@ -1,5 +1,11 @@
 ---
 sidebar_position: 3
+title: Typing Indicators
+description: Mocha forwards Discord typing indicators between every channel in a room so conversations feel native across servers. Here is exactly how it works and why loops don't form.
+keywords:
+  - discord typing indicator
+  - mocha typing
+  - cross-server typing
 ---
 
 # Typing Indicators

--- a/docs/commands/feedback.md
+++ b/docs/commands/feedback.md
@@ -1,5 +1,12 @@
 ---
 sidebar_position: 3
+title: "/feedback — Send Feedback to Mocha Developers"
+description: Use the /feedback slash command to send bug reports, suggestions, and feature requests directly to the Mocha developers from any Discord server.
+keywords:
+  - /feedback command
+  - mocha bug report
+  - mocha feature request
+  - discord bot feedback
 ---
 
 # Feedback

--- a/docs/commands/help.md
+++ b/docs/commands/help.md
@@ -1,5 +1,11 @@
 ---
 sidebar_position: 1
+title: "/help — Mocha Bot Command"
+description: The /help slash command shows the list of available Mocha commands and a quick link to mocha-bot.xyz. Use it to verify the bot is alive and find command names.
+keywords:
+  - /help command
+  - mocha help
+  - discord bot help
 ---
 
 # Help

--- a/docs/commands/room.md
+++ b/docs/commands/room.md
@@ -1,5 +1,14 @@
 ---
 sidebar_position: 2
+title: "/room — Mocha Bot Commands Reference"
+description: Full reference for the /room slash command and its subcommands — create, join, disconnect, switch, info, and invite — with every parameter and option.
+keywords:
+  - /room command
+  - mocha room
+  - room create
+  - room join
+  - room invite
+  - discord slash command
 ---
 
 # Room

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 1
+title: Mocha Bot Documentation
+description: Mocha is a Discord bot that links channels across different servers into shared rooms. Start here to invite the bot, create your first room, and bridge servers in under five minutes.
+keywords:
+  - mocha bot
+  - discord bot
+  - cross-server discord
+  - discord bridge
+  - discord rooms
 ---
 
 # Introduction

--- a/docs/others/acknowledgement.md
+++ b/docs/others/acknowledgement.md
@@ -1,5 +1,11 @@
 ---
 sidebar_position: 1
+title: Acknowledgements
+description: Mocha is built on top of open-source projects including DiscordGo, Echo, GORM, Asynq, Meilisearch, Next.js, and Docusaurus. Thanks to every maintainer and contributor.
+keywords:
+  - mocha credits
+  - open source
+  - acknowledgements
 ---
 
 # Acknowledgement

--- a/docs/others/frequent-searches.md
+++ b/docs/others/frequent-searches.md
@@ -1,5 +1,12 @@
 ---
 sidebar_position: 2
+title: Mocha FAQ — Frequent Searches
+description: Answers to the most common Mocha questions — inviting the bot, creating private rooms, temporary messages, sync windows, invitations, and ratings.
+keywords:
+  - mocha faq
+  - frequent questions
+  - mocha help
+  - discord bot faq
 ---
 
 # Frequent Searches

--- a/docs/rooms/invitations.md
+++ b/docs/rooms/invitations.md
@@ -1,5 +1,12 @@
 ---
 sidebar_position: 2
+title: Room Invitations
+description: Everything about Mocha invitation codes — aliases, max usage, expiration choices, redemption flow, and the feature gates that control which options your plan unlocks.
+keywords:
+  - room invitation
+  - invitation code
+  - room alias
+  - mocha invite
 ---
 
 # Invitations

--- a/docs/rooms/overview.md
+++ b/docs/rooms/overview.md
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 1
+title: Rooms Overview
+description: A Mocha room is a bridge that links Discord channels across different servers. Learn the properties, feature flags, and lifecycle of public and private rooms.
+keywords:
+  - mocha rooms
+  - discord rooms
+  - private room
+  - public room
+  - room feature flags
 ---
 
 # Overview

--- a/docs/rooms/personalization.md
+++ b/docs/rooms/personalization.md
@@ -1,5 +1,12 @@
 ---
 sidebar_position: 3
+title: Room Personalization
+description: Personalization relays messages through per-channel webhooks so each user's real avatar and display name appear on every bridged server. Learn how to enable it.
+keywords:
+  - mocha personalization
+  - discord webhook
+  - custom avatar
+  - cross server user
 ---
 
 # Personalization

--- a/docs/rooms/ratings.md
+++ b/docs/rooms/ratings.md
@@ -1,5 +1,11 @@
 ---
 sidebar_position: 4
+title: Room Ratings
+description: Rate Mocha rooms from 1 to 5 stars — one vote per user per room — and see how ratings surface in /room info and the public directory.
+keywords:
+  - room rating
+  - mocha ratings
+  - discord room stars
 ---
 
 # Ratings

--- a/docs/tutorials/connect-two-servers.md
+++ b/docs/tutorials/connect-two-servers.md
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 2
+title: Connect Two Discord Servers
+description: A complete walkthrough for bridging two Discord servers with Mocha — create a room on one side, join from the other, send test messages, and troubleshoot common permission issues.
+keywords:
+  - discord cross server chat
+  - bridge discord servers
+  - connect two discord servers
+  - mocha room tutorial
+  - discord multi server bot
 ---
 
 # Connect Two Servers

--- a/docs/tutorials/curate-your-room.md
+++ b/docs/tutorials/curate-your-room.md
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 4
+title: Curate and Moderate Your Mocha Room
+description: Manage a busy Mocha room end-to-end — edit details, inspect connected channels, kick misbehaving servers, enable personalization, leave ratings, and safely delete the room.
+keywords:
+  - moderate discord room
+  - manage mocha room
+  - kick discord channel
+  - mocha personalization
+  - discord room admin
 ---
 
 # Curate Your Room

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 1
+title: Getting Started with Mocha
+description: Invite the Mocha Discord bot to your server, configure the right permissions, create your first cross-server room, and verify the setup — all in under five minutes.
+keywords:
+  - mocha getting started
+  - invite mocha bot
+  - discord bot setup
+  - create discord room
+  - mocha permissions
 ---
 
 # Getting Started

--- a/docs/tutorials/share-via-invite.md
+++ b/docs/tutorials/share-via-invite.md
@@ -1,5 +1,13 @@
 ---
 sidebar_position: 3
+title: Share a Mocha Room via Invitation
+description: Generate invitation codes with custom aliases, usage limits, and expirations, share them with anyone, and let them join your Mocha room without copying IDs and passwords.
+keywords:
+  - mocha invitation
+  - discord room invite
+  - invite code
+  - room invite alias
+  - mocha share room
 ---
 
 # Share a Room via Invitation

--- a/docs/web/discover.md
+++ b/docs/web/discover.md
@@ -1,5 +1,12 @@
 ---
 sidebar_position: 1
+title: Discover Public Mocha Rooms
+description: Browse the public Mocha room directory at mocha-bot.xyz/search — filter by rating, channel count, and tags, and jump into a room with one tap.
+keywords:
+  - discover discord rooms
+  - public discord rooms
+  - mocha directory
+  - find discord room
 ---
 
 # Discover Rooms

--- a/docs/web/pricing.md
+++ b/docs/web/pricing.md
@@ -1,5 +1,14 @@
 ---
 sidebar_position: 3
+title: Mocha Pricing and Plans
+description: Mocha is free to use. Compare the Starter, Premium, and Pro plans to see which features — edit windows, personalization, room limits, and statistics — each plan unlocks.
+keywords:
+  - mocha pricing
+  - mocha plans
+  - starter plan
+  - premium plan
+  - pro plan
+  - discord bot pricing
 ---
 
 # Pricing

--- a/docs/web/room-page.md
+++ b/docs/web/room-page.md
@@ -1,5 +1,11 @@
 ---
 sidebar_position: 2
+title: Mocha Room Page
+description: Every public Mocha room has a page at mocha-bot.xyz/room/slug showing description, rating, tags, and a join modal with the room code you paste into Discord.
+keywords:
+  - room page
+  - mocha room
+  - join room code
 ---
 
 # Room Page

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,15 +2,32 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 const {themes} = require('prism-react-renderer');
-const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
+
+const siteUrl = 'https://docs.mocha-bot.xyz';
+const siteTitle = 'Mocha Bot Documentation';
+const siteDescription =
+  'Mocha is a Discord bot that links channels across Discord servers into shared rooms. Learn how to invite the bot, connect servers, manage rooms, share invitations, and use personalization, ratings, and more.';
+const siteKeywords = [
+  'mocha',
+  'mocha bot',
+  'discord bot',
+  'discord cross server chat',
+  'multi server discord',
+  'discord bridge bot',
+  'discord rooms',
+  'discord bot documentation',
+  'discord server bridge',
+  'cross-server messaging',
+];
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Mocha Bot Documentation',
+  title: siteTitle,
   tagline: 'Drink mocha with people across the universe',
-  url: 'https://docs.mocha-bot.xyz/',
+  url: siteUrl,
   baseUrl: '/',
+  trailingSlash: false,
   onBrokenLinks: 'throw',
   favicon: 'img/favicon.ico',
 
@@ -21,17 +38,70 @@ const config = {
   },
 
   // GitHub pages deployment config.
-  // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'mocha-bot', // Usually your GitHub org/user name.
-  projectName: 'docs', // Usually your repo name.
+  organizationName: 'mocha-bot',
+  projectName: 'docs',
 
-  // Even if you don't use internalization, you can use this field to set useful
-  // metadata like html lang. For example, if your site is Chinese, you may want
-  // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
   },
+
+  // Extra head tags for SEO — canonical hint, robots, theme color,
+  // structured data for search engines.
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'robots',
+        content: 'index, follow, max-image-preview:large, max-snippet:-1',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'theme-color',
+        content: '#000000',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'application-name',
+        content: 'Mocha Bot Docs',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'canonical',
+        href: siteUrl,
+      },
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        type: 'application/ld+json',
+      },
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: siteTitle,
+        alternateName: 'Mocha Bot Docs',
+        url: siteUrl,
+        description: siteDescription,
+        inLanguage: 'en',
+        publisher: {
+          '@type': 'Organization',
+          name: 'Mocha Bot',
+          url: 'https://mocha-bot.xyz',
+          logo: {
+            '@type': 'ImageObject',
+            url: `${siteUrl}/img/logo-mocha.png`,
+          },
+        },
+      }),
+    },
+  ],
 
   presets: [
     [
@@ -41,12 +111,19 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/mocha-bot/docs/tree/master/docs/',
+          showLastUpdateTime: true,
         },
+        blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
+        },
+        sitemap: {
+          lastmod: 'date',
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
         },
       }),
     ],
@@ -55,6 +132,29 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      image: 'img/logo-mocha.png',
+      metadata: [
+        {name: 'description', content: siteDescription},
+        {name: 'keywords', content: siteKeywords.join(', ')},
+        {name: 'author', content: 'Mocha Bot'},
+
+        // Open Graph
+        {property: 'og:type', content: 'website'},
+        {property: 'og:site_name', content: siteTitle},
+        {property: 'og:title', content: siteTitle},
+        {property: 'og:description', content: siteDescription},
+        {property: 'og:url', content: siteUrl},
+        {property: 'og:image', content: `${siteUrl}/img/logo-mocha.png`},
+        {property: 'og:image:alt', content: 'Mocha Bot logo'},
+        {property: 'og:locale', content: 'en_US'},
+
+        // Twitter
+        {name: 'twitter:card', content: 'summary_large_image'},
+        {name: 'twitter:title', content: siteTitle},
+        {name: 'twitter:description', content: siteDescription},
+        {name: 'twitter:image', content: `${siteUrl}/img/logo-mocha.png`},
+        {name: 'twitter:image:alt', content: 'Mocha Bot logo'},
+      ],
       colorMode: {
         defaultMode: 'dark',
         disableSwitch: true,
@@ -81,6 +181,35 @@ const config = {
       },
       footer: {
         style: 'dark',
+        links: [
+          {
+            title: 'Docs',
+            items: [
+              {label: 'Getting Started', to: '/tutorials/getting-started'},
+              {label: 'Commands', to: '/category/commands'},
+              {label: 'Rooms', to: '/category/rooms'},
+              {label: 'FAQ', to: '/others/frequent-searches'},
+            ],
+          },
+          {
+            title: 'Community',
+            items: [
+              {label: 'Support Server', href: 'https://discord.mocha-bot.xyz/'},
+              {label: 'Website', href: 'https://mocha-bot.xyz'},
+              {label: 'Pricing', to: '/web/pricing'},
+            ],
+          },
+          {
+            title: 'More',
+            items: [
+              {label: 'GitHub', href: 'https://github.com/mocha-bot'},
+              {
+                label: 'Edit on GitHub',
+                href: 'https://github.com/mocha-bot/docs',
+              },
+            ],
+          },
+        ],
         copyright: `Copyright © ${new Date().getFullYear()} Mocha Bot, Inc. Built with Docusaurus.`,
       },
       prism: {

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.mocha-bot.xyz/sitemap.xml


### PR DESCRIPTION
- Add site-wide description, keywords, Open Graph, and Twitter card metadata via themeConfig.metadata, plus a default og:image pointing at the Mocha logo.
- Inject robots meta, theme-color, canonical link, and a WebSite schema.org JSON-LD block via headTags.
- Configure the sitemap plugin (weekly changefreq, lastmod from date, ignore /tags) and add a static robots.txt pointing at it.
- Disable the unused blog preset so it no longer shows up in the sitemap.
- Add per-page title, description, and keywords frontmatter to every tutorial, command, chat, room, web, and others page so each has its own snippet, OG tags, and search-engine title.
- Add a three-column footer with docs, community, and external links for better site-level internal linking.
- Enable showLastUpdateTime and trailingSlash:false.